### PR TITLE
Issue #33: containerized stockpile storage with crafted containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ python3 /Users/henneberger/game2/game.py
 ## Test
 
 ```bash
-python3 -m unittest -v tests/test_economy_issue29.py
+python3 -m unittest -v tests/test_economy_issue29.py tests/test_balance_pass.py tests/test_container_storage_issue33.py
 ```
 
 ## Quick Start
@@ -43,14 +43,19 @@ zone pasture 24 10 0 5 4
 stockpile raw 8 8 0 4 3
 stockpile cooked 13 8 0 4 3
 stockpile drink 18 8 0 4 3
+stockpile food 23 8 0 4 3
 stockpile materials 1 12 0 8 3
 build workshop kitchen 11 7 0
 build workshop brewery 16 7 0
 build workshop carpenter 21 7 0
+build workshop loom 24 7 0
 tick 20
 order 1 meal 4
 order 2 brew 3
 order 3 bed 2
+order 3 barrel 2
+order 3 chest 1
+order 4 bag 2
 tick 25
 status
 panel events
@@ -61,10 +66,11 @@ panel events
 - Multi-z-level world with weather, seasons, and raid pressure.
 - Dwarves with multi-need simulation (`hunger`, `thirst`, `sleep`, `social`, `worship`, `entertainment`, `safety`), stress, moods, skills, labor priorities, and allowed/forbidden labors.
 - Zones: `farm`, `recreation`, `temple`, `dormitory`, `hospital`, `pasture`, `burrow`.
-- Workshops: `kitchen`, `brewery`, `carpenter`, `mason`, `craftdwarf`, `smithy`, `loom`, `leatherworks` with recipe orders.
+- Workshops: `kitchen`, `brewery`, `carpenter`, `mason`, `craftdwarf`, `smithy`, `loom`, `leatherworks` with recipe orders (including storage containers: `chest`, `barrel`, `bin`, `crate`, `bag`).
 - Item/entity simulation with materials, quality, value, perishability, ownership/reservation/carried state.
 - Food sim v2: nutrition pressure, storage-sensitive spoilage, and alcohol dependency effects.
 - Stockpiles with typed acceptance and hauling jobs.
+- Containerized storage where haulers can pack accepted items into `chest`, `barrel`, `bin`, `crate`, and `bag` based on stockpile type.
 - Social memory and relationship updates.
 - Justice events and crime records.
 - Squads, raid alerts, basic defense/training loop, injury/recovery.

--- a/docs/issue33_storage_output.txt
+++ b/docs/issue33_storage_output.txt
@@ -1,0 +1,66 @@
+=== ISSUE 33 CONTAINER PACKING VISUAL (seed=140) ===
+--- PANEL STOCKS ---
+bag: total=1 loose=1 contained=0
+barrel: total=1 loose=1 contained=0
+berry: total=1 loose=1 contained=0
+bin: total=2 loose=2 contained=0
+craft_good: total=4 loose=0 contained=4
+fiber: total=1 loose=0 contained=1
+herb: total=5 loose=2 contained=3
+hide: total=6 loose=6 contained=0
+manuscript: total=1 loose=0 contained=1
+rare_plant: total=1 loose=0 contained=1
+seed: total=4 loose=0 contained=4
+timber: total=4 loose=0 contained=4
+Containers:
+  [11] bag stockpile=1 load=8 mat=cloth
+  [12] barrel stockpile=2 load=0 mat=oak
+  [13] bin stockpile=3 load=5 mat=oak
+  [14] bin stockpile=4 load=5 mat=oak
+
+--- ITEMS (containers) ---
+[11] bag (5,5,0) mat=cloth q=0 v=3 age=180/0 stock=1 container=None carried=None reserved=None
+[12] barrel (7,5,0) mat=oak q=0 v=3 age=180/0 stock=2 container=None carried=None reserved=None
+[13] bin (9,5,0) mat=oak q=0 v=3 age=180/0 stock=3 container=None carried=None reserved=None
+[14] bin (11,5,0) mat=oak q=0 v=3 age=180/0 stock=4 container=None carried=None reserved=1
+
+--- ITEMS (contained) ---
+[15] seed (5,5,0) mat=spawn q=0 v=1 age=180/0 stock=1 container=11 carried=None reserved=None
+[16] seed (5,5,0) mat=spawn q=0 v=1 age=180/0 stock=1 container=11 carried=None reserved=None
+[17] seed (5,5,0) mat=spawn q=0 v=1 age=180/0 stock=1 container=11 carried=None reserved=None
+[18] seed (5,5,0) mat=spawn q=0 v=1 age=180/0 stock=1 container=11 carried=None reserved=None
+[23] craft_good (9,5,0) mat=stone q=0 v=3 age=180/0 stock=3 container=13 carried=None reserved=None
+[24] craft_good (9,5,0) mat=stone q=0 v=3 age=180/0 stock=3 container=13 carried=None reserved=None
+[25] craft_good (9,5,0) mat=stone q=0 v=3 age=180/0 stock=3 container=13 carried=None reserved=None
+[26] craft_good (9,5,0) mat=stone q=0 v=3 age=180/0 stock=3 container=13 carried=None reserved=None
+[27] timber (11,5,0) mat=oak q=0 v=3 age=180/0 stock=4 container=14 carried=None reserved=None
+[28] timber (11,5,0) mat=oak q=0 v=3 age=180/0 stock=4 container=14 carried=None reserved=None
+[29] timber (11,5,0) mat=oak q=0 v=3 age=180/0 stock=4 container=14 carried=None reserved=None
+[30] timber (11,5,0) mat=oak q=0 v=3 age=180/0 stock=4 container=14 carried=None reserved=None
+[33] herb (5,5,0) mat=typha-latifolia-forage q=0 v=2 age=162/110 stock=1 container=11 carried=None reserved=None
+[35] fiber (11,5,0) mat=sphagnum-spp.-fiber q=0 v=2 age=160/0 stock=4 container=14 carried=None reserved=None
+[37] herb (5,5,0) mat=allium-canadense-herb q=0 v=2 age=124/120 stock=1 container=11 carried=None reserved=None
+[39] rare_plant (5,5,0) mat=allium-canadense-rare-cutting q=0 v=5 age=124/150 stock=1 container=11 carried=None reserved=None
+[44] herb (5,5,0) mat=allium-canadense-herb q=0 v=2 age=83/120 stock=1 container=11 carried=None reserved=None
+[46] manuscript (9,5,0) mat=generic q=1 v=8 age=60/0 stock=3 container=13 carried=None reserved=None
+
+--- RENDER ---
+Tick 180 | z=0 | day=10 spring | weather=storm temp=9C
+food raw=0 cooked=0 drink=0 flora=35 wealth=80 raid=False
+Legend: D dwarf, a animal, workshops (lower=construction upper=built), f/r/t/d/h/p/b zones, stockpiles s c q k m g u + S, flora , ; " * + t y T Y A x, items R C A W O E F H B * L h b r M P X U N Q G
+.................x..............
+.H..............................
+.........x......................
+......H.D.......................
+................................
+.H...h.U+M+F....................
+........;.*...................x.
+.........;bD....................
+..H..............x..............
+...H....D+.......x..........+...
+.....a....+.....................
+.........*.+....................
+.........,"+x...+....x..........
+.h+..............;..............
+"+..............................
+,.........."+...................

--- a/fortress/engine.py
+++ b/fortress/engine.py
@@ -203,7 +203,7 @@ class Game(
         return zt
 
     def add_stockpile(self, kind: str, x: int, y: int, z: int, w: int, h: int) -> Stockpile:
-        if kind not in {"raw", "cooked", "drink", "materials", "goods", "medical", "furniture", "general"}:
+        if kind not in {"raw", "cooked", "drink", "food", "materials", "goods", "medical", "furniture", "general"}:
             raise ValueError("unknown stockpile kind")
         self._validate_rect(x, y, z, w, h)
         sp = Stockpile(id=self.next_stockpile_id, kind=kind, x=x, y=y, z=z, w=w, h=h)

--- a/fortress/io/commands.py
+++ b/fortress/io/commands.py
@@ -176,7 +176,7 @@ def help_text() -> str:
         "  zone <kind> <x> <y> <z> <w> <h>\n"
         "    kinds: farm recreation temple dormitory hospital pasture burrow\n"
         "  stockpile <kind> <x> <y> <z> <w> <h>\n"
-        "    kinds: raw cooked drink materials goods medical furniture general\n"
+        "    kinds: raw cooked drink food materials goods medical furniture general\n"
         "  build workshop <kind> <x> <y> <z>\n"
         "    kinds: kitchen brewery carpenter mason craftdwarf smithy loom leatherworks\n"
         "  order <workshop_id> <recipe> <amount>\n"

--- a/fortress/models.py
+++ b/fortress/models.py
@@ -24,6 +24,14 @@ LABORS = {
     "sleep",
 }
 
+CONTAINER_CAPACITY: Dict[str, int] = {
+    "chest": 8,
+    "barrel": 12,
+    "bin": 14,
+    "crate": 16,
+    "bag": 8,
+}
+
 
 def clamp(v: int, lo: int, hi: int) -> int:
     return max(lo, min(hi, v))
@@ -71,6 +79,8 @@ class Stockpile:
         cat = item_category(item_kind)
         if self.kind == "general":
             return True
+        if self.kind == "food":
+            return cat in {"raw", "cooked", "drink"}
         return self.kind == cat
 
     @property
@@ -109,6 +119,7 @@ class Item:
     stockpile_id: Optional[int] = None
     carried_by: Optional[int] = None
     reserved_by: Optional[int] = None
+    container_id: Optional[int] = None
 
 
 @dataclass
@@ -122,6 +133,7 @@ class Job:
     destination: Optional[Coord3] = None
     remaining: int = 1
     phase: str = ""
+    container_id: Optional[int] = None
 
 
 @dataclass
@@ -331,13 +343,17 @@ def item_category(kind: str) -> str:
     if kind in {"raw_food", "herb", "berry", "rare_plant"}:
         return "raw"
     if kind in {"seed"}:
-        return "materials"
+        return "raw"
     if kind in {"cooked_food"}:
         return "cooked"
     if kind in {"alcohol"}:
         return "drink"
     if kind in {"wood", "stone", "ore", "fiber", "hide", "timber"}:
         return "materials"
+    if kind in {"barrel", "bin", "crate", "bag"}:
+        return "materials"
+    if kind in {"chest"}:
+        return "furniture"
     if kind in {"craft_good", "artifact", "manuscript", "performance_record"}:
         return "goods"
     if kind in {"bandage", "medicine"}:
@@ -345,3 +361,7 @@ def item_category(kind: str) -> str:
     if kind in {"bed", "chair", "table"}:
         return "furniture"
     return "general"
+
+
+def is_container_kind(kind: str) -> bool:
+    return kind in CONTAINER_CAPACITY

--- a/fortress/systems/defs.py
+++ b/fortress/systems/defs.py
@@ -11,13 +11,23 @@ class DefsMixin:
             "recipes": {
                 "kitchen": {"meal": {"inputs": {"raw_food": 1}, "outputs": {"cooked_food": 1}, "time": 4, "value_bonus": 3}},
                 "brewery": {"brew": {"inputs": {"raw_food": 1}, "outputs": {"alcohol": 1}, "time": 4, "value_bonus": 2}},
-                "carpenter": {"bed": {"inputs": {"wood": 1}, "outputs": {"bed": 1}, "time": 5, "value_bonus": 5}},
+                "carpenter": {
+                    "bed": {"inputs": {"wood": 1}, "outputs": {"bed": 1}, "time": 5, "value_bonus": 5},
+                    "chest": {"inputs": {"wood": 1}, "outputs": {"chest": 1}, "time": 5, "value_bonus": 4},
+                    "barrel": {"inputs": {"wood": 1}, "outputs": {"barrel": 1}, "time": 4, "value_bonus": 3},
+                    "bin": {"inputs": {"timber": 1}, "outputs": {"bin": 1}, "time": 5, "value_bonus": 4},
+                    "crate": {"inputs": {"timber": 1}, "outputs": {"crate": 1}, "time": 5, "value_bonus": 4},
+                },
                 "mason": {"block": {"inputs": {"stone": 1}, "outputs": {"craft_good": 1}, "time": 3, "value_bonus": 2}},
                 "craftdwarf": {"trinket": {"inputs": {"stone": 1}, "outputs": {"craft_good": 1}, "time": 3, "value_bonus": 3}},
                 "smithy": {"tool": {"inputs": {"ore": 1}, "outputs": {"craft_good": 1}, "time": 6, "value_bonus": 6}},
-                "loom": {"cloth": {"inputs": {"fiber": 1}, "outputs": {"craft_good": 1}, "time": 4, "value_bonus": 4}},
+                "loom": {
+                    "cloth": {"inputs": {"fiber": 1}, "outputs": {"craft_good": 1}, "time": 4, "value_bonus": 4},
+                    "bag": {"inputs": {"fiber": 1}, "outputs": {"bag": 1}, "time": 4, "value_bonus": 3},
+                },
                 "leatherworks": {
-                    "leather_gear": {"inputs": {"hide": 1}, "outputs": {"craft_good": 1}, "time": 4, "value_bonus": 4}
+                    "leather_gear": {"inputs": {"hide": 1}, "outputs": {"craft_good": 1}, "time": 4, "value_bonus": 4},
+                    "bag": {"inputs": {"hide": 1}, "outputs": {"bag": 1}, "time": 4, "value_bonus": 3},
                 },
             },
             "creatures": {"goat": {"graze": 1}, "boar": {"graze": 1}},

--- a/fortress/systems/jobs.py
+++ b/fortress/systems/jobs.py
@@ -194,10 +194,20 @@ class JobSystemsMixin(JobExecutionMixin):
 
         # Hauling.
         if self._labor_allowed(dwarf, "haul"):
-            item, stock = self._find_haul_candidate()
+            item, stock, container = self._find_haul_candidate()
             if item and stock:
                 item.reserved_by = dwarf.id
-                return self._new_job(kind="haul", labor="haul", item_id=item.id, target_id=stock.id, destination=self._item_pos(item), phase="to_item")
+                if container:
+                    container.reserved_by = dwarf.id
+                return self._new_job(
+                    kind="haul",
+                    labor="haul",
+                    item_id=item.id,
+                    target_id=stock.id,
+                    container_id=container.id if container else None,
+                    destination=self._item_pos(item),
+                    phase="to_item",
+                )
 
         # Recreation, social, worship.
         if dwarf.needs["entertainment"] >= 60 and self._find_zone("recreation", dwarf.z):

--- a/fortress/systems/world.py
+++ b/fortress/systems/world.py
@@ -115,6 +115,23 @@ class WorldSystemsMixin:
     def _economy_tick(self) -> None:
         if self.tick_count % 40 == 0:
             self.economy_stats["trees_felled_recent"] = max(0, self.economy_stats.get("trees_felled_recent", 0) - 1)
+        if self.tick_count % 30 == 0:
+            for sp in self.stockpiles:
+                if self._stockpile_loose_item_count(sp) < 4:
+                    continue
+                loose = next(
+                    (
+                        i
+                        for i in self.items
+                        if i.stockpile_id == sp.id and i.container_id is None and i.kind not in {"chest", "barrel", "bin", "crate", "bag"}
+                    ),
+                    None,
+                )
+                if not loose:
+                    continue
+                if self._find_compatible_container(sp, loose.kind):
+                    continue
+                self._request_container_for_stockpile(sp, loose.kind)
 
         active = [m for m in self.mandates if not m.fulfilled and not m.failed]
         if len(active) < 2 and self.tick_count % 120 == 0:

--- a/tests/test_container_storage_issue33.py
+++ b/tests/test_container_storage_issue33.py
@@ -1,0 +1,112 @@
+import os
+import tempfile
+import unittest
+
+from fortress.engine import Game
+
+
+def run_job_until_idle(game: Game, dwarf_id: int, max_steps: int = 40) -> None:
+    dwarf = game._find_dwarf(dwarf_id)
+    assert dwarf is not None
+    for _ in range(max_steps):
+        if dwarf.job is None:
+            return
+        game._perform_job_step(dwarf)
+    raise AssertionError("job did not complete")
+
+
+class ContainerStorageIssue33Tests(unittest.TestCase):
+    def test_container_recipes_exist(self) -> None:
+        g = Game(rng_seed=301)
+        carpenter = g.defs["recipes"]["carpenter"]
+        loom = g.defs["recipes"]["loom"]
+        self.assertTrue({"chest", "barrel", "bin", "crate"}.issubset(set(carpenter.keys())))
+        self.assertIn("bag", loom)
+
+    def test_seed_hauling_uses_bag_in_raw_stockpile(self) -> None:
+        g = Game(rng_seed=302)
+        g.items = []
+        sp = g.add_stockpile("raw", 5, 5, 0, 1, 1)
+        bag = g._spawn_item("bag", 5, 5, 0, material="cloth", value=3)
+        bag.stockpile_id = sp.id
+        seed = g._spawn_item("seed", 1, 1, 0, material="plump-helmet-spawn", value=1)
+
+        item, stock, container = g._find_haul_candidate()
+        self.assertEqual(item.id if item else None, seed.id)
+        self.assertEqual(stock.id if stock else None, sp.id)
+        self.assertEqual(container.id if container else None, bag.id)
+
+        d = g.dwarves[0]
+        seed.reserved_by = d.id
+        bag.reserved_by = d.id
+        d.job = g._new_job(
+            kind="haul",
+            labor="haul",
+            item_id=seed.id,
+            target_id=sp.id,
+            container_id=bag.id,
+            destination=(seed.x, seed.y, seed.z),
+            phase="to_item",
+        )
+        run_job_until_idle(g, d.id)
+
+        self.assertEqual(seed.stockpile_id, sp.id)
+        self.assertEqual(seed.container_id, bag.id)
+
+    def test_alcohol_hauling_uses_barrel_in_drink_stockpile(self) -> None:
+        g = Game(rng_seed=303)
+        g.items = []
+        sp = g.add_stockpile("drink", 6, 5, 0, 1, 1)
+        barrel = g._spawn_item("barrel", 6, 5, 0, material="oak", value=3)
+        barrel.stockpile_id = sp.id
+        booze = g._spawn_item("alcohol", 1, 1, 0, material="ale", value=2, perishability=150)
+
+        item, stock, container = g._find_haul_candidate()
+        self.assertEqual(item.id if item else None, booze.id)
+        self.assertEqual(stock.id if stock else None, sp.id)
+        self.assertEqual(container.id if container else None, barrel.id)
+
+    def test_container_items_route_to_policy_stockpiles(self) -> None:
+        g = Game(rng_seed=304)
+        g.items = []
+        raw_sp = g.add_stockpile("raw", 4, 4, 0, 2, 2)
+        furn_sp = g.add_stockpile("furniture", 10, 4, 0, 2, 2)
+        chest = g._spawn_item("chest", 1, 1, 0, material="oak", value=4)
+        barrel = g._spawn_item("barrel", 2, 1, 0, material="oak", value=3)
+
+        i1, s1, c1 = g._find_haul_candidate()
+        self.assertEqual(i1.id if i1 else None, chest.id)
+        self.assertEqual(s1.id if s1 else None, furn_sp.id)
+        self.assertIsNone(c1)
+
+        chest.reserved_by = 999
+        i2, s2, c2 = g._find_haul_candidate()
+        self.assertEqual(i2.id if i2 else None, barrel.id)
+        self.assertEqual(s2.id if s2 else None, raw_sp.id)
+        self.assertIsNone(c2)
+
+    def test_save_load_preserves_container_links(self) -> None:
+        g = Game(rng_seed=305)
+        g.items = []
+        sp = g.add_stockpile("raw", 5, 5, 0, 1, 1)
+        bag = g._spawn_item("bag", 5, 5, 0, material="cloth", value=3)
+        bag.stockpile_id = sp.id
+        seed = g._spawn_item("seed", 5, 5, 0, material="spawn", value=1)
+        seed.stockpile_id = sp.id
+        seed.container_id = bag.id
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as tf:
+            path = tf.name
+        try:
+            g.save_json(path)
+            loaded = Game.load_json(path)
+            loaded_seed = next(i for i in loaded.items if i.kind == "seed")
+            loaded_bag = next(i for i in loaded.items if i.kind == "bag")
+            self.assertEqual(loaded_seed.container_id, loaded_bag.id)
+            self.assertEqual(loaded_seed.stockpile_id, loaded_bag.stockpile_id)
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements #33 end-to-end: crafted containers (`chest`, `barrel`, `bin`, `crate`, `bag`), stockpile-type container policies, and container-aware dwarf hauling/storage.

Closes #33.

## What was implemented
- New container item support:
  - `Item.container_id` for packed item linkage.
  - Container kinds/capacity in model constants.
- New stockpile type:
  - `food` stockpile added (accepts raw/cooked/drink categories).
- New crafting path:
  - Carpenter recipes: `chest`, `barrel`, `bin`, `crate`.
  - Loom/Leatherworks recipes: `bag`.
- Stockpile-aware container routing:
  - Container policy by stockpile type (`raw`, `drink`, `goods`, `materials`, etc.).
  - Container items route to stockpiles where they are useful (not only by category).
- Container-aware hauling:
  - Haul candidate selection now picks compatible container when available.
  - Haul job tracks optional `container_id` target.
  - Items are packed into containers on delivery (with capacity + compatibility checks).
  - Reservation release for both hauled item and container.
- Logistics auto-queue (v1 heuristic):
  - Economy tick queues container production when a stockpile has many loose items and lacks suitable containers.
- Storage accounting + introspection:
  - Stockpile slot usage counts loose items/containers (contained items don’t consume tile slots).
  - `panel stocks` now shows total/loose/contained counts and container occupancy lines.
  - `items` output now includes `container=<id|None>`.
  - Render glyphs + legend updated for container items.
- Save/load compatibility:
  - `container_id` is persisted via dataclass serialization and validated by test.

## Visual (actual text game output)
From `/Users/henneberger/game2/docs/issue33_storage_output.txt`:

```text
=== ISSUE 33 CONTAINER PACKING VISUAL (seed=140) ===
--- PANEL STOCKS ---
bag: total=1 loose=1 contained=0
barrel: total=1 loose=1 contained=0
bin: total=2 loose=2 contained=0
craft_good: total=4 loose=0 contained=4
seed: total=4 loose=0 contained=4
timber: total=4 loose=0 contained=4
Containers:
  [11] bag stockpile=1 load=8 mat=cloth
  [13] bin stockpile=3 load=5 mat=oak
  [14] bin stockpile=4 load=5 mat=oak

--- ITEMS (contained) ---
[15] seed ... stock=1 container=11 ...
[23] craft_good ... stock=3 container=13 ...
[27] timber ... stock=4 container=14 ...
```

## Tests
Ran:
- `python3 -m py_compile game.py fortress/*.py fortress/io/*.py fortress/systems/*.py tests/*.py`
- `python3 -m unittest -v tests/test_economy_issue29.py tests/test_balance_pass.py tests/test_container_storage_issue33.py`

Added tests in `tests/test_container_storage_issue33.py`:
- recipe presence for all container types
- seed -> bag behavior in raw stockpile
- alcohol -> barrel behavior in drink stockpile
- container item routing to policy stockpiles
- save/load preserving `container_id` links
