### PR TITLE
Allow surface animals to graze outside pasture

### DIFF
--- a/fortress/systems/world.py
+++ b/fortress/systems/world.py
@@ -151,8 +151,15 @@ class WorldSystemsMixin:
         pasture = self._find_zone("pasture")
         for a in self.animals:
             a.hunger = clamp(a.hunger + 2, 0, 100)
-            if pasture and a.z == pasture.z:
-                a.hunger = clamp(a.hunger - 3, 0, 100)
+            in_pasture = pasture is not None and pasture.contains(a.pos)
+            if in_pasture:
+                a.hunger = clamp(a.hunger - 4, 0, 100)
+            elif a.z == 0:
+                # Surface grazing prevents starvation for free-ranging animals.
+                graze = 2
+                if self.rng.random() < 0.35:
+                    graze += 1
+                a.hunger = clamp(a.hunger - graze, 0, 100)
             if self.rng.random() < 0.3:
                 nx = clamp(a.x + self.rng.choice([-1, 0, 1]), 0, self.width - 1)
                 ny = clamp(a.y + self.rng.choice([-1, 0, 1]), 0, self.height - 1)

--- a/tests/test_animal_grazing.py
+++ b/tests/test_animal_grazing.py
@@ -1,0 +1,30 @@
+import unittest
+
+from fortress.engine import Game
+
+
+class AnimalGrazingTests(unittest.TestCase):
+    def test_surface_animals_do_not_starve_outside_pasture(self) -> None:
+        g = Game(rng_seed=501)
+        g.animals = []
+        goat = g.add_animal("goat", 10, 10, 0)
+        goat.hunger = 90
+        g.rng.random = lambda: 1.0  # no movement, no extra graze bonus
+        for _ in range(200):
+            g._animal_tick()
+        self.assertLess(goat.hunger, 95)
+        self.assertEqual(len([a for a in g.animals if a.species == "goat"]), 1)
+
+    def test_underground_animals_can_still_starve_without_pasture(self) -> None:
+        g = Game(rng_seed=502, depth=3)
+        g.animals = []
+        goat = g.add_animal("goat", 10, 10, 1)
+        goat.hunger = 94
+        g.rng.random = lambda: 1.0
+        g._animal_tick()
+        self.assertEqual(goat.hunger, 40)
+        self.assertTrue(any("died of neglect" in e.text for e in g.events if e.kind == "animal"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adjusts animal hunger behavior so surface animals can graze while free-ranging, instead of starving only because they are outside a pasture zone.

## Changes
- Updated `/Users/henneberger/game2/fortress/systems/world.py`:
  - Keep baseline hunger increase.
  - If animal is inside pasture: strong hunger recovery.
  - If animal is on surface (`z=0`) outside pasture: passive grazing recovery each tick.
  - Underground animals without pasture still follow starvation pressure.
- Added `/Users/henneberger/game2/tests/test_animal_grazing.py`:
  - `test_surface_animals_do_not_starve_outside_pasture`
  - `test_underground_animals_can_still_starve_without_pasture`

## Validation
```bash
python3 -m py_compile fortress/systems/world.py tests/test_animal_grazing.py
python3 -m unittest -q tests/test_animal_grazing.py
python3 -m unittest -q tests/test_balance_pass.py tests/test_container_storage_issue33.py
```
All passing.
